### PR TITLE
Potential fix for code scanning alert no. 2: Missing rate limiting

### DIFF
--- a/src/app/dist/index.js
+++ b/src/app/dist/index.js
@@ -168,7 +168,11 @@ function serveStatic(app2) {
     );
   }
   app2.use(express.static(distPath));
-  app2.use("*", (_req, res) => {
+  const staticFileLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // max 100 requests per windowMs
+  });
+  app2.use("*", staticFileLimiter, (_req, res) => {
     res.sendFile(path2.resolve(distPath, "index.html"));
   });
 }


### PR DESCRIPTION
Potential fix for [https://github.com/Nikhil-Kadapala/clef2025-checkthat-lab-task2/security/code-scanning/2](https://github.com/Nikhil-Kadapala/clef2025-checkthat-lab-task2/security/code-scanning/2)

To address the issue, we will add rate limiting to the route that serves the static file (`res.sendFile(path2.resolve(distPath, "index.html"))`). This can be achieved using the `express-rate-limit` package, which is already imported in the code (`import rateLimit from "express-rate-limit";`). We will configure a rate limiter with reasonable limits (e.g., 100 requests per 15 minutes) and apply it to the route.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
