### PR TITLE
Potential fix for code scanning alert no. 4: Missing rate limiting

### DIFF
--- a/src/app/server/vite.ts
+++ b/src/app/server/vite.ts
@@ -85,7 +85,12 @@ export function serveStatic(app: Express) {
   app.use(express.static(distPath));
 
   // fall through to index.html if the file doesn't exist
-  app.use("*", (_req, res) => {
+  const fallbackLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // max 100 requests per windowMs
+  });
+
+  app.use("*", fallbackLimiter, (_req, res) => {
     res.sendFile(path.resolve(distPath, "index.html"));
   });
 }


### PR DESCRIPTION
Potential fix for [https://github.com/Nikhil-Kadapala/clef2025-checkthat-lab-task2/security/code-scanning/4](https://github.com/Nikhil-Kadapala/clef2025-checkthat-lab-task2/security/code-scanning/4)

To address the issue, we will add rate limiting to the fallback route handler on line 88. This will involve using the `express-rate-limit` middleware, which is already imported in the file. We will configure a rate limiter with appropriate settings (e.g., a maximum of 100 requests per 15 minutes) and apply it to the fallback route. This ensures that the file system access in the fallback route is protected against excessive requests.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
